### PR TITLE
don't require .git postfix on remote addresses

### DIFF
--- a/lib/App/GitHubPullRequest.pm
+++ b/lib/App/GitHubPullRequest.pm
@@ -323,7 +323,7 @@ sub _find_github_remote {
         my ($remote, $url, $type) = split /\s+/, $line;
         next unless $type eq '(fetch)'; # only consider fetch remotes
         next unless $url =~ m/github\.com/; # only consider remotes to github
-        if ( $url =~ m{github.com[:/](.+)\.git$} ) {
+        if ( $url =~ m{github.com[:/](.+)(\.git)?$} ) {
             $repo = $1;
             last;
         }


### PR DESCRIPTION
Hi! Thanks for writing this! I got lucky and caught it posted to reddit just now - a few days ago I was looking for EXACTLY this tool.

I ran into this problem in the first repository I ran it in, but it was just a tiny fix.

I plan on writing another feature (I'll make another pull of course) that will automatically pull the patch and make a new tracking branch locally (or just switch me to it if it already exists). I am constantly using this workflow and I've been meaning to automate it for a while. This gives me the perfect base upon which to do so.
