### PR TITLE
added `prq checkout` feature

### DIFF
--- a/lib/App/GitHubPullRequest.pm
+++ b/lib/App/GitHubPullRequest.pm
@@ -151,7 +151,8 @@ sub checkout {
     my $remote = $prq->{head}{repo}{git_url};
     my $branch = $prq->{head}{'ref'};
     my $contributor = $prq->{user}{login};
-    _qx('git', "remote add --fetch --track $branch $contributor $remote");
+    _qx('git', "remote add --fetch --track $branch $contributor $remote")
+        unless grep {/$contributor/} _qx('git', "remote");
     _qx('git', "checkout remotes/$contributor/$branch");
     return 0;
 }


### PR DESCRIPTION
Added a feature to automate the process of creating a new remote
corresponding to the contributing repository of a pull request and
checking out the commit referenced.

Documentation still needs to be updated.
