### PR TITLE
renamed executable for integration with git

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,7 @@
 Revision history for App-GitHubPullRequest
 
 {{$NEXT}}
-    - renamed prq to git-pull-request for git integration (PR#5)
+    - renamed prq to git-pr for git integration (PR#5)
 
 0.2.0     2013-03-09 11:37:12 Europe/Oslo
     - Added checkout command (PR#4)

--- a/README.mkdn
+++ b/README.mkdn
@@ -8,17 +8,17 @@ version 0.2.0
 
 # SYNOPSIS
 
-    $ git pull-request
-    $ git pull-request list closed # not shown by default
-    $ git pull-request show 7      # also includes comments
-    $ git pull-request patch 7     # can be piped to colordiff if you like colors
-    $ git pull-request checkout 7  # create upstream tracking branch pr/7
-    $ git pull-request help
+    $ git pr
+    $ git pr list closed # not shown by default
+    $ git pr show 7      # also includes comments
+    $ git pr patch 7     # can be piped to colordiff if you like colors
+    $ git pr checkout 7  # create upstream tracking branch pr/7
+    $ git pr help
 
-    $ git pull-request login       # Get access token for commands below
-    $ git pull-request close 7
-    $ git pull-request open 7
-    $ git pull-request comment 7 'This is good stuff!'
+    $ git pr login       # Get access token for commands below
+    $ git pr close 7
+    $ git pr open 7
+    $ git pr comment 7 'This is good stuff!'
 
 # INSTALLATION
 
@@ -95,7 +95,7 @@ prompted for them.
 ## run(@args)
 
 Calls any of the other listed public methods with specified arguments. This
-is usually called automatically when you invoke [git-pull-request](http://search.cpan.org/perldoc?git-pull-request).
+is usually called automatically when you invoke [git-pr](http://search.cpan.org/perldoc?git-pr).
 
 # DEBUGGING
 
@@ -106,7 +106,7 @@ If you want to interact with another GitHub repo than the one in your
 current directory, set the environment variable GITHUB\_REPO to the name of
 the repo in question. Example:
 
-    GITHUB_REPO=robinsmidsrod/App-GitHubPullRequest git pull-request list
+    GITHUB_REPO=robinsmidsrod/App-GitHubPullRequest git pr list
 
 Be aware, that if that repo is a fork, the program will look for its parent.
 
@@ -122,7 +122,7 @@ have a remote that points to github.com for the tool to work.
 
 # SEE ALSO
 
-- [git-pull-request](http://search.cpan.org/perldoc?git-pull-request)
+- [git-pr](http://search.cpan.org/perldoc?git-pr)
 - [GitHub Pull Request documentation](https://help.github.com/articles/using-pull-requests)
 - [GitHub Pull Request API documentation](http://developer.github.com/v3/pulls/)
 

--- a/bin/git-pr
+++ b/bin/git-pr
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 # ABSTRACT: Command-line tool to query GitHub pull requests
-# PODNAME: git pull-request
+# PODNAME: git pr
 
 use strict;
 use warnings;
@@ -17,17 +17,17 @@ exit $rc;
 
 =head1 SYNOPSIS
 
-    $ git pull-request
-    $ git pull-request list closed # not shown by default
-    $ git pull-request show 7      # also includes comments
-    $ git pull-request patch 7     # can be piped to colordiff if you like colors
-    $ git pull-request checkout 7  # create upstream tracking branch pr/7
-    $ git pull-request help
+    $ git pr
+    $ git pr list closed # not shown by default
+    $ git pr show 7      # also includes comments
+    $ git pr patch 7     # can be piped to colordiff if you like colors
+    $ git pr checkout 7  # create upstream tracking branch pr/7
+    $ git pr help
 
-    $ git pull-request login       # Get access token for commands below
-    $ git pull-request close 7
-    $ git pull-request open 7
-    $ git pull-request comment 7 'This is good stuff!'
+    $ git pr login       # Get access token for commands below
+    $ git pr close 7
+    $ git pr open 7
+    $ git pr comment 7 'This is good stuff!'
 
 
 =head1 INSTALLATION

--- a/lib/App/GitHubPullRequest.pm
+++ b/lib/App/GitHubPullRequest.pm
@@ -19,7 +19,7 @@ sub new {
 =method run(@args)
 
 Calls any of the other listed public methods with specified arguments. This
-is usually called automatically when you invoke L<git-pull-request>.
+is usually called automatically when you invoke L<git-pr>.
 
 =cut
 
@@ -344,7 +344,7 @@ sub login {
     my $token = $auth->{'token'};
     die("Authentication data does not include a token.\n")
         unless $token;
-    my ($content, $rc) = _run_ext(qw(git config --global github.git-pull-request-token), $token);
+    my ($content, $rc) = _run_ext(qw(git config --global github.git-pr-token), $token);
     die("git config returned message '$content' and code $rc when trying to store your token.\n")
         if $rc != 0;
     say "Access token stored successfully. Go to https://github.com/settings/applications to revoke access.";
@@ -450,7 +450,7 @@ sub _tmpfile {
     srand($$ + time);
     my $random = $$;
     $random .= int(rand(10)) for 1..10;
-    return "/tmp/git-pull-request-$prefix$random";
+    return "/tmp/git-pr-$prefix$random";
 }
 
 # Return stdout from external program
@@ -499,7 +499,7 @@ If you want to interact with another GitHub repo than the one in your
 current directory, set the environment variable GITHUB_REPO to the name of
 the repo in question. Example:
 
-    GITHUB_REPO=robinsmidsrod/App-GitHubPullRequest git pull-request list
+    GITHUB_REPO=robinsmidsrod/App-GitHubPullRequest git pr list
 
 Be aware, that if that repo is a fork, the program will look for its parent.
 
@@ -517,7 +517,7 @@ sub _get_url {
     # See if we should use credentials
     my @credentials;
     if ( $url =~ m{^https://api.github.com/} ) {
-        my $token = _qx('git', 'config github.git-pull-request-token');
+        my $token = _qx('git', 'config github.git-pr-token');
         @credentials = ( '-H', "Authorization: token $token" ) if $token;
     }
 
@@ -549,7 +549,7 @@ sub _patch_url {
     # See if we should use credentials
     my @credentials;
     if ( $url =~ m{^https://api.github.com/} ) {
-        my $token = _qx('git', 'config github.git-pull-request-token');
+        my $token = _qx('git', 'config github.git-pr-token');
         die("You must login before you can modify information.\n")
             unless $token;
         @credentials = ( '-H', "Authorization: token $token" );
@@ -592,7 +592,7 @@ sub _post_url {
     # See if we should use credentials
     my @credentials;
     if ( $url =~ m{^https://api.github.com/} ) {
-        my $token = _qx('git', 'config github.git-pull-request-token');
+        my $token = _qx('git', 'config github.git-pr-token');
         die("You must login before you can modify information.\n")
             unless $token or ( $user and $password );
         if ( $user and $password ) {
@@ -628,17 +628,17 @@ sub _post_url {
 
 =head1 SYNOPSIS
 
-    $ git pull-request
-    $ git pull-request list closed # not shown by default
-    $ git pull-request show 7      # also includes comments
-    $ git pull-request patch 7     # can be piped to colordiff if you like colors
-    $ git pull-request checkout 7  # create upstream tracking branch pr/7
-    $ git pull-request help
+    $ git pr
+    $ git pr list closed # not shown by default
+    $ git pr show 7      # also includes comments
+    $ git pr patch 7     # can be piped to colordiff if you like colors
+    $ git pr checkout 7  # create upstream tracking branch pr/7
+    $ git pr help
 
-    $ git pull-request login       # Get access token for commands below
-    $ git pull-request close 7
-    $ git pull-request open 7
-    $ git pull-request comment 7 'This is good stuff!'
+    $ git pr login       # Get access token for commands below
+    $ git pr close 7
+    $ git pr open 7
+    $ git pr comment 7 'This is good stuff!'
 
 
 =head1 INSTALLATION
@@ -670,7 +670,7 @@ have a remote that points to github.com for the tool to work.
 =head1 SEE ALSO
 
 =for :list
-* L<git-pull-request>
+* L<git-pr>
 * L<GitHub Pull Request documentation|https://help.github.com/articles/using-pull-requests>
 * L<GitHub Pull Request API documentation|http://developer.github.com/v3/pulls/>
 


### PR DESCRIPTION
Git looks for commands in the form git-\* when parsing command arguments.
Therefore, with this rename, we can call the program naturally:

git pull-request list
