### PR TITLE
allow the command format `git pr checkout pr/#`

### DIFF
--- a/lib/App/GitHubPullRequest.pm
+++ b/lib/App/GitHubPullRequest.pm
@@ -148,11 +148,15 @@ added and the branch in question will be fetched.
 
 sub checkout {
     my ($self, $number) = @_;
-    $number =~ s{[^\d]}{}g;
-    die("Please specify a pull request number.\n") unless $number;
-    my $pr = $self->_fetch_one($number);
-    die("Unable to fetch pull request $number.\n")
-        unless defined $pr;
+    my $pr;
+    $number =~ s{[^\d]}{}g if defined $number;
+    if ($number) {
+        $pr = $self->_fetch_one($number);
+        die("Unable to fetch pull request $number.\n")
+            unless defined $pr;
+    } else {
+        die("Please specify a pull request number.\n");
+    }
 
     # Get required contributor branch info
     my $head_repo   = $pr->{'head'}->{'repo'}->{'git_url'};


### PR DESCRIPTION
it's a little silly, but because the branches get named that way,
sometimes I try to check out the branches with this format.
