### PR TITLE
check ssh host aliases when no explicit github url

### DIFF
--- a/lib/App/GitHubPullRequest.pm
+++ b/lib/App/GitHubPullRequest.pm
@@ -418,7 +418,7 @@ sub _find_github_remote {
         foreach my $possible_aliased_url ( @possible_aliased_urls ) {
             my ($possible_aliased_host, $repository) = split ':', $possible_aliased_url;
             my $ssh_config = Net::SSH::Perl::Config->new($possible_aliased_host);
-            $ssh_config->read_config("/home/$ENV{USER}/.ssh/config");
+            $ssh_config->read_config("$ENV{HOME}/.ssh/config");
             if ($ssh_config->get('hostname')
                     and $ssh_config->get('hostname') eq 'github.com'
                     and $ssh_config->get('user') eq 'git') {


### PR DESCRIPTION
I add use ssh host aliases i.e:

Host gh
    HostName github.com
    User git

This means I can reference remotes in the form gh:user/repo.
Unfortunately, git-pr is currently blind to that. But no longer!

One not so nice thing is that Net::SSH::Perl::Config forces you to
reinstantiate its object (and reread the file) to look for a different
host. I'm going to see if I can patch that package to make it a bit
nicer for us in this regard. However, it's still quite quick - and this
code only runs if a "normal" github.com url is not found.
