### PR TITLE
Add support for `pr checkout` of origin branches

### DIFF
--- a/lib/App/GitHubPullRequest.pm
+++ b/lib/App/GitHubPullRequest.pm
@@ -168,7 +168,7 @@ sub checkout {
         if ( $url eq $head_repo ) {
             $head_remote = $remote;
         }
-        if ( $remote eq 'origin' and $url =~ m/github\.com:$repo_owner/) {
+        if ( $remote eq 'origin' and $url =~ m/github\.com:$repo_owner\//) {
             $head_remote = 'origin';
             last;
         }


### PR DESCRIPTION
When working with a team and submitting branches for code review that
have been pushed to the master repository, `pr checkout` fails to
properly fetch from origin/ prefaced branches. This fixes that.

I avoided using the s//r non-destructive regex modifier to retain
support for older perls.
